### PR TITLE
Add voxel MultiMesh rendering with collider updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Godot CI
+
+on:
+  push: { branches: [main] }
+  pull_request: {}
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: firebelley/godot-export@v4
+        with:
+          godot-version: '4.2.1'
+          export-preset: 'Windows Desktop'
+          output-dir: build/windows
+      - uses: firebelley/godot-export@v4
+        with:
+          godot-version: '4.2.1'
+          export-preset: 'Web'
+          output-dir: build/web
+      - uses: actions/upload-artifact@v4
+        with:
+          name: game-builds
+          path: build/**
+      - name: Deploy Web build to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/web

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
-# Godot 4+ specific ignores
+# Godot 4 cache & temp
+.import/
 .godot/
+godot.export/
+
+# OS junk
+Thumbs.db
+.DS_Store
+
+# Editor temp files
+*.tmp
+*.temp
+
+build/

--- a/Goal.gd
+++ b/Goal.gd
@@ -1,0 +1,12 @@
+extends Area3D
+
+@onready var ui := Label.new()
+
+func _ready():
+    connect("body_entered", _on_body_entered)
+
+func _on_body_entered(body):
+    if body.name == "Player":
+        print("You win!")
+        get_tree().quit()
+

--- a/Goal.tscn
+++ b/Goal.tscn
@@ -1,0 +1,14 @@
+[gd_scene format=3]
+
+[ext_resource path="res://Goal.gd" type="Script" id=1]
+
+[node name="Goal" type="Area3D"]
+script = ExtResource(1)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = CubeMesh.new()
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = BoxShape3D.new()
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/Goal.tscn
+++ b/Goal.tscn
@@ -6,7 +6,7 @@
 script = ExtResource(1)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
-mesh = CubeMesh.new()
+mesh = BoxMesh.new()
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 shape = BoxShape3D.new()

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,0 +1,47 @@
+[gd_scene format=3]
+
+[ext_resource path="res://Player.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Goal.tscn" type="PackedScene" id=2]
+[ext_resource path="res://World.tscn" type="PackedScene" id=3]
+[ext_resource path="res://VoxelTool.gd" type="Script" id=4]
+[ext_resource path="res://UI.tscn" type="PackedScene" id=5]
+
+[node name="Main" type="Node3D"]
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+rotation_degrees = Vector3(-60, 45, 0)
+
+[node name="World" parent="." instance=ExtResource(3)]
+
+[node name="Obstacle1" type="StaticBody3D" parent="."]
+position = Vector3(2, 0.5, 2)
+
+[node name="Mesh" type="MeshInstance3D" parent="Obstacle1"]
+mesh = CubeMesh.new()
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle1"]
+shape = BoxShape3D.new()
+
+[node name="Obstacle2" type="StaticBody3D" parent="."]
+position = Vector3(-3, 0.5, -1)
+
+[node name="Mesh" type="MeshInstance3D" parent="Obstacle2"]
+mesh = CubeMesh.new()
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle2"]
+shape = BoxShape3D.new()
+
+[node name="Player" parent="." instance=ExtResource(1)]
+position = Vector3(0, 1, 0)
+
+[node name="VoxelTool" type="Node3D" parent="Player/Camera3D"]
+script = ExtResource(4)
+
+[node name="RayCast3D" type="RayCast3D" parent="Player/Camera3D/VoxelTool"]
+target_position = Vector3(0, 0, -5)
+enabled = true
+
+[node name="Goal" parent="." instance=ExtResource(2)]
+position = Vector3(0, 0.5, 5)
+
+[node name="UI" parent="." instance=ExtResource(5)]

--- a/Main.tscn
+++ b/Main.tscn
@@ -17,7 +17,7 @@ rotation_degrees = Vector3(-60, 45, 0)
 position = Vector3(2, 0.5, 2)
 
 [node name="Mesh" type="MeshInstance3D" parent="Obstacle1"]
-mesh = CubeMesh.new()
+mesh = BoxMesh.new()
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle1"]
 shape = BoxShape3D.new()
@@ -26,7 +26,7 @@ shape = BoxShape3D.new()
 position = Vector3(-3, 0.5, -1)
 
 [node name="Mesh" type="MeshInstance3D" parent="Obstacle2"]
-mesh = CubeMesh.new()
+mesh = BoxMesh.new()
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle2"]
 shape = BoxShape3D.new()

--- a/Player.gd
+++ b/Player.gd
@@ -1,0 +1,28 @@
+extends CharacterBody3D
+
+@export var speed := 5.0
+@export var jump_velocity := 4.0
+
+var gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
+
+func _physics_process(delta: float) -> void:
+    var direction := Vector3(
+        Input.get_action_strength("move_right") - Input.get_action_strength("move_left"),
+        0.0,
+        Input.get_action_strength("move_backward") - Input.get_action_strength("move_forward")
+    )
+
+    if direction.length() > 0:
+        direction = direction.normalized()
+        velocity.x = direction.x * speed
+        velocity.z = direction.z * speed
+    else:
+        velocity.x = move_toward(velocity.x, 0.0, speed)
+        velocity.z = move_toward(velocity.z, 0.0, speed)
+
+    if not is_on_floor():
+        velocity.y -= gravity * delta
+    elif Input.is_action_just_pressed("jump"):
+        velocity.y = jump_velocity
+
+    move_and_slide()

--- a/Player.tscn
+++ b/Player.tscn
@@ -6,7 +6,7 @@
 script = ExtResource(1)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
-mesh = CubeMesh.new()
+mesh = BoxMesh.new()
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 shape = BoxShape3D.new()

--- a/Player.tscn
+++ b/Player.tscn
@@ -1,0 +1,17 @@
+[gd_scene format=3]
+
+[ext_resource path="res://Player.gd" type="Script" id=1]
+
+[node name="Player" type="CharacterBody3D"]
+script = ExtResource(1)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = CubeMesh.new()
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = BoxShape3D.new()
+
+[node name="Camera3D" type="Camera3D" parent="."]
+position = Vector3(0, 2, -6)
+rotation_degrees = Vector3(0, 180, 0)
+current = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
-# Cradle-to-Crucible
-Minimal Godot 4 voxel project scaffold.
+# Cradle-to-Crucible (prototype)
+A tiny Godot 4 project demonstrating a simple voxel-style movement test.
 
 ## How to run
-1. Open with Godot 4.x
-2. Press F5 to run
+1. Open the project with Godot 4.x.
+2. Press **F5** to play.
+
+### Controls
+- **WASD**: Move the player cube
+- **Space**: Jump
+- **Esc**: Quit
+- **Left-click**: Mine block
+- **Right-click**: Build block
+- Cross-hair indicates current target block
+- Engine now batches ground cubes via MultiMesh
+
+## Local export
+Run the helper script if the Godot CLI is installed:
+
+```bash
+./tools/export.sh
+```
+
+CI automatically builds Windows and Web versions on every push.
+

--- a/UI.tscn
+++ b/UI.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=3]
+
+[node name="UI" type="CanvasLayer"]
+
+[node name="Crosshair" type="Label" parent="."]
+text = "+"
+anchor_left = 0.5
+anchor_right = 0.5
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = -8
+offset_top = -8

--- a/VoxelTerrain.gd
+++ b/VoxelTerrain.gd
@@ -3,7 +3,7 @@ extends Node3D
 @export var size_x := 16
 @export var size_z := 16
 
-var cube_mesh := CubeMesh.new()
+var cube_mesh := BoxMesh.new()
 var material := StandardMaterial3D.new()
 var multimesh := MultiMesh.new()
 var multimesh_instance := MultiMeshInstance3D.new()

--- a/VoxelTerrain.gd
+++ b/VoxelTerrain.gd
@@ -1,0 +1,62 @@
+extends Node3D
+
+@export var size_x := 16
+@export var size_z := 16
+
+var cube_mesh := CubeMesh.new()
+var material := StandardMaterial3D.new()
+var multimesh := MultiMesh.new()
+var multimesh_instance := MultiMeshInstance3D.new()
+var blocks := {}
+
+func _spawn_block(pos: Vector3i, index: int = -1) -> Dictionary:
+    if index == -1:
+        index = multimesh.instance_count
+        multimesh.instance_count += 1
+
+    multimesh.set_instance_transform(index, Transform3D(Basis(), pos))
+    multimesh.set_instance_visible(index, true)
+    multimesh.set_instance_color(index, Color.WHITE)
+
+    var body = StaticBody3D.new()
+    var shape = CollisionShape3D.new()
+    var box = BoxShape3D.new()
+    box.size = Vector3.ONE
+    shape.shape = box
+    body.add_child(shape)
+    body.position = pos
+    add_child(body)
+
+    return {"index": index, "body": body}
+
+func _ready():
+    material.albedo_color = Color(0.6, 0.8, 0.6)
+
+    multimesh.transform_format = MultiMesh.TRANSFORM_3D
+    multimesh.color_format = MultiMesh.COLOR_8BIT
+
+    multimesh_instance.multimesh = multimesh
+    multimesh_instance.mesh = cube_mesh
+    multimesh_instance.material_override = material
+    add_child(multimesh_instance)
+
+    var i = 0
+    multimesh.instance_count = size_x * size_z
+    for x in range(size_x):
+        for z in range(size_z):
+            var pos := Vector3i(x, 0, z)
+            multimesh.set_instance_transform(i, Transform3D(Basis(), pos))
+            multimesh.set_instance_visible(i, true)
+            multimesh.set_instance_color(i, Color.WHITE)
+
+            var body = StaticBody3D.new()
+            var shape = CollisionShape3D.new()
+            var box = BoxShape3D.new()
+            box.size = Vector3.ONE
+            shape.shape = box
+            body.add_child(shape)
+            body.position = pos
+            add_child(body)
+
+            blocks[pos] = {"index": i, "body": body}
+            i += 1

--- a/VoxelTool.gd
+++ b/VoxelTool.gd
@@ -1,0 +1,66 @@
+extends Node3D
+
+@export var reach := 5.0
+var blocks := {}
+var world
+var multimesh : MultiMesh
+var highlighted_index := -1
+var last_highlighted_index := -1
+@onready var ray := $RayCast3D
+
+func _ready():
+    world = get_tree().current_scene.get_node("World")
+    ray.target_position = Vector3(0, 0, -reach)
+    ray.enabled = true
+    var terrain = world.get_node("VoxelTerrain")
+    await terrain.ready
+    blocks = terrain.blocks
+    multimesh = terrain.multimesh
+
+func _physics_process(delta):
+    ray.force_raycast_update()
+    var idx := -1
+    if ray.is_colliding():
+        var p = ray.get_collision_point()
+        var pos = Vector3i(int(round(p.x)), int(round(p.y)), int(round(p.z)))
+        if blocks.has(pos):
+            idx = blocks[pos]["index"]
+    highlighted_index = idx
+
+func _process(delta):
+    if multimesh == null:
+        return
+    if highlighted_index != last_highlighted_index:
+        if last_highlighted_index >= 0:
+            multimesh.set_instance_color(last_highlighted_index, Color.WHITE)
+        if highlighted_index >= 0:
+            multimesh.set_instance_color(highlighted_index, Color.RED)
+        last_highlighted_index = highlighted_index
+
+func _unhandled_input(event):
+    if multimesh == null:
+        return
+    if not ray.is_colliding():
+        return
+    var p = ray.get_collision_point()
+    var n = ray.get_collision_normal()
+    var block_pos = Vector3i(int(round(p.x)), int(round(p.y)), int(round(p.z)))
+    if event.is_action_pressed("mine"):
+        if blocks.has(block_pos):
+            var data = blocks[block_pos]
+            multimesh.set_instance_visible(data["index"], false)
+            data["body"].queue_free()
+            blocks.erase(block_pos)
+    elif event.is_action_pressed("build"):
+        var place_pos = block_pos + Vector3i(int(n.x), int(n.y), int(n.z))
+        if not blocks.has(place_pos):
+            var terrain = world.get_node("VoxelTerrain")
+            var index := -1
+            for i in range(multimesh.instance_count):
+                if not multimesh.is_instance_visible(i):
+                    index = i
+                    break
+            if index == -1:
+                index = multimesh.instance_count
+                multimesh.instance_count += 1
+            blocks[place_pos] = terrain._spawn_block(place_pos, index)

--- a/World.tscn
+++ b/World.tscn
@@ -1,0 +1,8 @@
+[gd_scene format=3]
+
+[ext_resource path="res://VoxelTerrain.gd" type="Script" id=1]
+
+[node name="World" type="Node3D"]
+
+[node name="VoxelTerrain" type="Node3D" parent="." ]
+script = ExtResource(1)

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,0 +1,13 @@
+[preset.0]
+name="Windows Desktop"
+platform="Windows"
+output_file="build/windows/Cradle.exe"
+runnable=true
+options/debug=false
+
+[preset.1]
+name="Web"
+platform="Web"
+output_file="build/web/index.html"
+runnable=true
+options/debug=false

--- a/project.godot
+++ b/project.godot
@@ -9,7 +9,16 @@
 config_version=5
 
 [application]
-
 config/name="Fracture-forge"
 config/features=PackedStringArray("4.0", "Forward Plus")
 config/icon="res://icon.svg"
+run/main_scene="res://Main.tscn"
+
+[input]
+move_forward={"deadzone":0.5,"events":[{"type":"key","keycode":87}]}
+move_backward={"deadzone":0.5,"events":[{"type":"key","keycode":83}]}
+move_left={"deadzone":0.5,"events":[{"type":"key","keycode":65}]}
+move_right={"deadzone":0.5,"events":[{"type":"key","keycode":68}]}
+jump={"deadzone":0.5,"events":[{"type":"key","keycode":32}]}
+mine={"deadzone":0.5,"events":[{"type":"mouse_button","button_index":1}]}
+build={"deadzone":0.5,"events":[{"type":"mouse_button","button_index":2}]}

--- a/tools/export.sh
+++ b/tools/export.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if ! command -v godot &>/dev/null; then
+  echo "Godot CLI not found. Install Godot 4.x and add it to PATH."
+  exit 0
+fi
+
+godot --headless --export-release "Windows Desktop" build/Cradle.exe
+godot --headless --export-release "Web" build/web/index.html


### PR DESCRIPTION
## Summary
- replace per-block meshes with a MultiMesh in `VoxelTerrain`
- manage block slots in `VoxelTool` for mining/building
- highlight blocks by coloring MultiMesh instances
- note the MultiMesh batching in README
- fix crash by typing gravity and waiting for terrain `ready`

## Testing
- `./tools/export.sh` *(prints missing Godot CLI message)*

------
https://chatgpt.com/codex/tasks/task_e_68731641ec34832b8a70121069d93d00